### PR TITLE
fix: action image-release

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -6,6 +6,12 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
 
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build-and-push:
     if: ${{ github.repository == 'khulnasoft/alpine-curl' }}
@@ -21,12 +27,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8026d2bc3645ea78b0d2544766a1225eb5691f89
 
-      - name: Login to quay.io
+      - name: Login to ghcr.io
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_RELEASE_ALPINE_CURL_USERNAME }}
-          password: ${{ secrets.QUAY_RELEASE_ALPINE_CURL_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Getting image tag
         id: tag
@@ -45,8 +51,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
-            quay.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}-ci:${{ github.sha }}
 
       - name: Image Release Digest
         shell: bash
@@ -59,7 +65,7 @@ jobs:
 
           echo "### ${{ matrix.name }}" > image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
-          echo "\`quay.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
+          echo "\`ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests


### PR DESCRIPTION
### **User description**
**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [*] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the Docker image release workflow to use GitHub Container Registry (`ghcr.io`) instead of `quay.io`.
- Introduced environment variables for registry and image name to streamline configuration.
- Changed authentication method to use GitHub actor and token for logging into the registry.
- Updated image tag references to reflect the new registry.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>image-release.yaml</strong><dd><code>Update Docker image release workflow to use GitHub Container Registry</code></dd></summary>
<hr>

.github/workflows/image-release.yaml

<li>Added environment variables for registry and image name.<br> <li> Changed login registry from <code>quay.io</code> to <code>ghcr.io</code>.<br> <li> Updated image tags to use <code>ghcr.io</code>.<br> <li> Modified authentication to use GitHub actor and token.<br>


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/alpine-curl/pull/5/files#diff-7cf697d30b92f206dacab0ee46e116f832f1b1089f48488e148834bdb73fc918">+13/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

## Summary by Sourcery

CI:
- Update the image-release workflow to use GitHub Container Registry (ghcr.io) instead of Quay.io for Docker image management.